### PR TITLE
add dump function and associated tests

### DIFF
--- a/addons/yaml_dot_gd/run_tests.gd
+++ b/addons/yaml_dot_gd/run_tests.gd
@@ -6,6 +6,7 @@ func _ready():
 	var multiline_test = load("res://addons/yaml_dot_gd/tests/test_multiline.gd").new()
 	var advanced_test = load("res://addons/yaml_dot_gd/tests/test_advanced.gd").new()
 	
+	var dump_test = load("res://addons/yaml_dot_gd/tests/dump/dump_test.gd")
 	# Run tests
 	var all_passed = true
 	
@@ -21,6 +22,11 @@ func _ready():
 	
 	print("=== Running Advanced Tests ===")
 	if !advanced_test.run():
+		all_passed = false
+	print("\n")
+	
+	print("=== Running Dump Tests ===")
+	if !dump_test.run():
 		all_passed = false
 	print("\n")
 	

--- a/addons/yaml_dot_gd/tests/dump/dump_test.gd
+++ b/addons/yaml_dot_gd/tests/dump/dump_test.gd
@@ -1,0 +1,83 @@
+@tool
+extends EditorScript
+
+func _run() -> void:
+	var all_passed = run()
+	print("")
+	if all_passed:
+		print("✅ ALL TESTS PASSED")
+	else:
+		print("❌ SOME TESTS FAILED")
+
+static func run():
+	var all_passed = true
+	var files_passed = test_files()
+	if !files_passed:
+		all_passed = false
+	
+	return all_passed
+
+
+static func test_files():
+	var files = [
+		"res://addons/yaml_dot_gd/tests/yamls/advanced/test_01.yaml",
+		"res://addons/yaml_dot_gd/tests/yamls/advanced/test_02.yaml",
+		"res://addons/yaml_dot_gd/tests/yamls/advanced/test_03.yaml",
+		"res://addons/yaml_dot_gd/tests/yamls/advanced/test_04.yaml",
+		"res://addons/yaml_dot_gd/tests/yamls/advanced/test_05.yaml",
+		"res://addons/yaml_dot_gd/tests/yamls/advanced/test_06.yaml",
+		"res://addons/yaml_dot_gd/tests/yamls/basic/test_01.yaml",
+		"res://addons/yaml_dot_gd/tests/yamls/basic/test_02.yaml",
+		"res://addons/yaml_dot_gd/tests/yamls/basic/test_03.yaml",
+		"res://addons/yaml_dot_gd/tests/yamls/basic/test_04.yaml",
+		"res://addons/yaml_dot_gd/tests/yamls/basic/test_05.yaml",
+		"res://addons/yaml_dot_gd/tests/yamls/multiline/test_01.yaml",
+		"res://addons/yaml_dot_gd/tests/yamls/multiline/test_02.yaml",
+		"res://addons/yaml_dot_gd/tests/yamls/multiline/test_03.yaml",
+		"res://addons/yaml_dot_gd/tests/yamls/multiline/test_04.yaml",
+		"res://addons/yaml_dot_gd/tests/yamls/multiline/test_05.yaml",
+	]
+	var all_passed = true
+	for f in files:
+		var passed = _test_dump_and_read(f)
+		if !passed:
+			all_passed = false
+	
+	return all_passed
+
+static func _test_dump_and_read(file_path:String, save_to_file:bool=false):
+	if not FileAccess.file_exists(file_path):
+		print("Fail - File not present: ", file_path)
+		return false
+	var text = FileAccess.get_file_as_string(file_path)
+	var parser = YAMLParser.new()
+	var file_data = parser.parse(text)
+	
+	var dumped = YAMLParser.dump(file_data)
+	var reparsed_data = parser.parse(dumped)
+	
+	var passed = file_data == reparsed_data
+	if passed:
+		print("PASSED: ", file_path)
+	else:
+		print("FAIL: ", file_path)
+		print("")
+		print("--- Expected ---")
+		print(file_data)
+		print("")
+		print("--- Parsed ---")
+		print(reparsed_data)
+		
+		print("")
+		print("--- Dumped ---")
+		print(dumped)
+	
+	if !save_to_file:
+		return passed
+	
+	var new_path = "res://.godot".path_join(file_path.get_base_dir().get_file()).path_join(file_path.get_file())
+	DirAccess.make_dir_recursive_absolute(new_path.get_base_dir())
+	var f = FileAccess.open(new_path, FileAccess.WRITE)
+	f.store_string(dumped)
+	
+	return passed

--- a/addons/yaml_dot_gd/tests/dump/dump_test.gd.uid
+++ b/addons/yaml_dot_gd/tests/dump/dump_test.gd.uid
@@ -1,0 +1,1 @@
+uid://dw0okvt8lmnpk

--- a/addons/yaml_dot_gd/yaml.gd
+++ b/addons/yaml_dot_gd/yaml.gd
@@ -608,3 +608,76 @@ static func _string_safe_split(line: String, delim:String, first_delim:=true) ->
 			parts.append(last_string)
 	
 	return parts
+
+
+# dump and utils
+static func dump(data, indent: int = 0) -> String:
+	if (data is Dictionary or data is Array) and data.is_empty():
+		return "{}" if data is Dictionary else "[]"
+
+	var lines = []
+	var pad = "  ".repeat(indent)
+
+	if data is Dictionary:
+		for key in data:
+			var safe_key = _scalar(key)
+			var val = data[key]
+			if val is Dictionary or val is Array:
+				if val.is_empty():
+					lines.append("%s%s: %s" % [pad, safe_key, "{}" if val is Dictionary else "[]"])
+				else:
+					lines.append("%s%s:" % [pad, safe_key])
+					lines.append(dump(val, indent + 1))
+			else:
+				lines.append("%s%s: %s" % [pad, safe_key, _scalar(val)])
+	elif data is Array:
+		for item in data:
+			if item is Dictionary or item is Array:
+				if item.is_empty():
+					lines.append("%s- %s" % [pad, "{}" if item is Dictionary else "[]"])
+				else:
+					lines.append("%s-" % pad)
+					lines.append(dump(item, indent + 1))
+			else:
+				lines.append("%s- %s" % [pad, _scalar(item)])
+
+	return "\n".join(lines)
+
+
+static func _scalar(val) -> String:
+	if val == null:
+		return "null"
+	if val is bool:
+		return "true" if val else "false"
+	if val is int or val is float:
+		return str(val)
+
+	var s = str(val)
+	if s.is_empty():
+		return '""'
+
+	var needs_quotes = false
+	var lower_s = s.to_lower()
+	if lower_s in ["true", "false", "null", "yes", "no", "on", "off", "~"]:
+		needs_quotes = true
+	elif s.is_valid_float() or s.is_valid_int():
+		needs_quotes = true
+
+	var special_chars = [
+		":", "{", "}", "[", "]", ",", "&", "*", "#", "?", "|",
+		"-", "<", ">", "=", "!", "%", "@", "`", "\n", "\"", "\\"
+	]
+	if not needs_quotes:
+		for c in special_chars:
+			if c in s:
+				needs_quotes = true
+				break
+
+	if s.begins_with(" ") or s.ends_with(" "):
+		needs_quotes = true
+
+	if needs_quotes:
+		s = s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
+		return '"%s"' % s
+
+	return s


### PR DESCRIPTION
Hello!

This PR add's a dump static function that will convert data to a yaml string you can write to a file.
I added a test script that will run on all your test files:
 - parses the file directly to data
 - dumps the file to yaml string
 - re-parses the dumped yaml string
 - compare that the data is identical

All tests are passing except for "advanced/test_03"
```
items:
  - string
  - 42
  - true
  - 
    key: value
  - [1, 2, 3]
```

Is being converted to:
```
items:
  - string
  - 42
  - true
  -
    key: value
  -
    - 1
    - 2
    - 3
```

There is no way to tell what the data looks like without preserving some type of metadata when reading it, so it dumps to standard yaml and this output is valid and equivalent to the input.

The result:
```
--- Expected ---
{ "items": ["string", 42, true, { "key": "value" }, [1, 2, 3]] }

--- Parsed ---
{ "items": ["string", 42, true, { "key": "value" }, {  }] }
```

So something needs some tweaking in the parse function, but that's outside of the scope of this PR

Possibly related to: https://github.com/lowlevel-1989/YAML.gd/issues/4
If that is fixed, I think it's likely this scenario would be too